### PR TITLE
Fix dyad equality

### DIFF
--- a/Pitch/NoteNumberRepresentableDyad.swift
+++ b/Pitch/NoteNumberRepresentableDyad.swift
@@ -31,9 +31,7 @@ public protocol NoteNumberRepresentableDyad: Equatable {
 // MARK: - Equatable
 
 
-/**
- - returns: `true` if the values contained in each value are equivalent. Otherwise `false`.
- */
+/// - returns: `true` if the values contained in each value are equivalent. Otherwise `false`.
 public func == <T: NoteNumberRepresentableDyad> (lhs: T, rhs: T) -> Bool {
-    return lhs.lower == rhs.higher
+    return lhs.lower == rhs.lower && lhs.higher == rhs.higher
 }

--- a/Pitch/NoteNumberRepresentableInterval.swift
+++ b/Pitch/NoteNumberRepresentableInterval.swift
@@ -21,3 +21,4 @@ public protocol NoteNumberRepresentableInterval: NoteNumberRepresentable {
     /// Create a `NoteNumberRepresentableInterval` with two values of type `Element`.
     init(_ a: Element, _ b: Element)
 }
+

--- a/Pitch/PitchDyad.swift
+++ b/Pitch/PitchDyad.swift
@@ -50,10 +50,3 @@ extension PitchDyad: CustomStringConvertible {
     /// Printed description
     public var description: String { return "\(lower), \(higher)" }
 }
-
-/**
- - returns: `true` if the values contained in each value are equivalent. Otherwise `false`.
- */
-public func == (lhs: PitchDyad, rhs: PitchDyad) -> Bool {
-    return lhs.lower == rhs.lower && lhs.higher == rhs.higher
-}

--- a/PitchTests/PitchDyadTests.swift
+++ b/PitchTests/PitchDyadTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Pitch
+import Pitch
 
 class PitchDyadTests: XCTestCase {
     
@@ -27,9 +27,27 @@ class PitchDyadTests: XCTestCase {
         XCTAssertEqual(dyad.description, "60.0, 62.0")
     }
     
-    func testEquality() {
-        let dyad1 = PitchDyad(Pitch(60.0), Pitch(62.0))
-        let dyad2 = PitchDyad(Pitch(60.0), Pitch(62.0))
-        XCTAssert(dyad1 == dyad2)
+    func testEqualityTrue() {
+        let a: PitchDyad = .init(60,62)
+        let b: PitchDyad = .init(60,62)
+        XCTAssert(a == b)
+    }
+    
+    func testEqualityFalseHigherNotEqual() {
+        let a: PitchDyad = .init(60,62)
+        let b: PitchDyad = .init(60,63)
+        XCTAssertFalse(a == b)
+    }
+    
+    func testEqualityFalseLowerNotEqual() {
+        let a: PitchDyad = .init(60,62)
+        let b: PitchDyad = .init(59,62)
+        XCTAssertFalse(a == b)
+    }
+    
+    func testEqualityFalseNeitherEqual() {
+        let a: PitchDyad = .init(60,63)
+        let b: PitchDyad = .init(59,62)
+        XCTAssertFalse(a == b)
     }
 }

--- a/PitchTests/PitchIntervalTests.swift
+++ b/PitchTests/PitchIntervalTests.swift
@@ -22,5 +22,11 @@ class PitchIntervalTests: XCTestCase {
         let dyad = PitchDyad(Pitch(60.0), Pitch(62.0))
         let interval = PitchInterval(dyad: dyad)
         XCTAssertEqual(interval, 2.0)
-    } 
+    }
+    
+    func testEquatable() {
+        let a: PitchInterval = .init(48, 51)
+        let b: PitchInterval = .init(48, 51)
+        XCTAssert(a == b)
+    }
 }


### PR DESCRIPTION
- Removes concrete implementation of `==` for `PitchDyad`
- Fixes small bug in `NoteNumberRepresentableDyad` implementation of `==`.