### PR TITLE
Update usage of adjacentPairs

### DIFF
--- a/Pitch/PitchClassCollection.swift
+++ b/Pitch/PitchClassCollection.swift
@@ -45,7 +45,7 @@ public struct PitchClassCollection: NoteNumberRepresentableCollection {
     /// - TODO: Refactor up the `NoteNumberRepresentableCollection` protocol hierarchy
     public lazy var intervals: PitchClassIntervalCollection = {
         return PitchClassIntervalCollection(
-            self.array.adjacentPairs?.map(PitchClassInterval.init) ?? []
+            self.array.adjacentPairs().map(PitchClassInterval.init)
         )
     }()
     

--- a/Pitch/PitchCollection.swift
+++ b/Pitch/PitchCollection.swift
@@ -29,7 +29,7 @@ public struct PitchCollection: NoteNumberRepresentableCollection {
 
     /// Collection of `PitchInterval` values between adjacent values contained herein.
     public var intervals: PitchIntervalCollection {
-        return PitchIntervalCollection(array.adjacentPairs?.map(PitchInterval.init) ?? [])
+        return PitchIntervalCollection(array.adjacentPairs().map(PitchInterval.init))
     }
 }
 


### PR DESCRIPTION
BidirectionalCollection.adjacentPairs no longer produces an optional result (https://github.com/dn-m/Collections/commit/48704116231cd7cd6a18047a5295af32ce9c8faa). So, update usage to build correctly.